### PR TITLE
Fixed default settings not reseting opacity

### DIFF
--- a/Uppers Bubbles/main.lua
+++ b/Uppers Bubbles/main.lua
@@ -271,7 +271,7 @@ function UppersBubbles.SetupHooks()
             function MenuCallbackHandler:uppers_bubbles_default_callback(item)
                 MenuHelper:ResetItemsToDefaultValue(
                     item,
-                    {["uppers_bubbles_red"] = true},
+                    {["uppers_bubbles_opacity"] = true},
                     UppersBubbles.default_settings.opacity
                 )
 


### PR DESCRIPTION
noticed it didn't reset so i looked at the code decided to try to change this because it didn't look like it was supposed to be red and it fixed the problem